### PR TITLE
Removed Retryable module inclusion

### DIFF
--- a/lib/mega_mutex/distributed_mutex.rb
+++ b/lib/mega_mutex/distributed_mutex.rb
@@ -6,7 +6,6 @@ module MegaMutex
   class TimeoutError < Exception; end
 
   class DistributedMutex
-    include Retryable
 
     class << self
       def cache


### PR DESCRIPTION
Since new versions of the gem retryable don't actually use a Retryable module, it can be safely removed
