### PR TITLE
Adding support for passing TTL to dalli

### DIFF
--- a/lib/mega_mutex.rb
+++ b/lib/mega_mutex.rb
@@ -56,8 +56,16 @@ module MegaMutex
   #   with_distributed_mutex('my_mutex_id_1234', :timeout => 20) do
   #     do_something!
   #   end
+  #
+  # Additionally, you can specify the amount of time the lock should be valid
+  # for. This is helpful in preventing deadlocks when the lock isn't deleted
+  # for whatever reason.
+  #
+  #   with_distributed_mutex('my_mutex_id_1234', :ttl => 20) do
+  #     do_something!
+  #   end
   def with_distributed_mutex(mutex_id, options = {}, &block)
-    mutex = DistributedMutex.new(mutex_id, options[:timeout])
+    mutex = DistributedMutex.new(mutex_id, options[:timeout], options[:ttl])
     begin
       mutex.run(&block)
     rescue Object => e

--- a/lib/mega_mutex/distributed_mutex.rb
+++ b/lib/mega_mutex/distributed_mutex.rb
@@ -11,9 +11,10 @@ module MegaMutex
       end
     end
 
-    def initialize(key, timeout = nil)
+    def initialize(key, timeout = nil, ttl = nil)
       @key = key
       @timeout = timeout
+      @ttl = ttl
     end
 
     def logger
@@ -74,7 +75,7 @@ module MegaMutex
     end
 
     def set_current_lock(new_lock)
-      cache.add(@key, my_lock_id)
+      cache.add(@key, my_lock_id, @ttl)
     end
 
     def my_lock_id

--- a/spec/lib/mega_mutex_spec.rb
+++ b/spec/lib/mega_mutex_spec.rb
@@ -129,5 +129,25 @@ module MegaMutex
         assert @exception.is_a?(MegaMutex::TimeoutError), "Expected TimeoutError to be raised, but wasn't"
       end
     end
+
+    describe 'with a TTL' do
+      it "should release the lock after the TTL has expired" do
+        messages = []
+
+        threads << Thread.new do
+          with_distributed_mutex('foo', :ttl => 0.2) do
+            sleep 0.4
+            messages << 'Second message'
+          end
+        end
+        threads << Thread.new do
+          with_distributed_mutex('foo') { messages << 'First message' }
+        end
+
+        wait_for_threads_to_finish
+        messages.first.should eq('First message')
+        messages.first.should eq('Second message')
+      end
+    end
   end
 end


### PR DESCRIPTION
Setting a TTL can be useful for preventing deadlocks (if the process fails inexplicably, for example).