### PR TITLE
Adding support for passing TTL to dalli

### DIFF
--- a/lib/mega_mutex.rb
+++ b/lib/mega_mutex.rb
@@ -56,8 +56,16 @@ module MegaMutex
   #   with_distributed_mutex('my_mutex_id_1234', :timeout => 20) do
   #     do_something!
   #   end
+  #
+  # Additionally, you can specify the amount of time the lock should be valid
+  # for. This is helpful in preventing deadlocks when the lock isn't deleted
+  # for whatever reason.
+  #
+  #   with_distributed_mutex('my_mutex_id_1234', :ttl => 20) do
+  #     do_something!
+  #   end
   def with_distributed_mutex(mutex_id, options = {}, &block)
-    mutex = DistributedMutex.new(mutex_id, options[:timeout])
+    mutex = DistributedMutex.new(mutex_id, options[:timeout], options[:ttl])
     begin
       mutex.run(&block)
     rescue Object => e

--- a/lib/mega_mutex/distributed_mutex.rb
+++ b/lib/mega_mutex/distributed_mutex.rb
@@ -11,9 +11,10 @@ module MegaMutex
       end
     end
 
-    def initialize(key, timeout = nil)
+    def initialize(key, timeout = nil, ttl = nil)
       @key = key
       @timeout = timeout
+      @ttl = ttl
     end
 
     def logger
@@ -74,7 +75,7 @@ module MegaMutex
     end
 
     def set_current_lock(new_lock)
-      cache.add(@key, my_lock_id)
+      cache.add(@key, my_lock_id, @ttl)
     end
 
     def my_lock_id

--- a/lib/mega_mutex/distributed_mutex.rb
+++ b/lib/mega_mutex/distributed_mutex.rb
@@ -1,8 +1,9 @@
 require 'logging'
 require 'dalli'
+require "byebug"
 
 module MegaMutex
-  class TimeoutError < Exception; end
+  class TimeoutError < RuntimeError; end
 
   class DistributedMutex
     class << self

--- a/lib/mega_mutex/distributed_mutex.rb
+++ b/lib/mega_mutex/distributed_mutex.rb
@@ -1,6 +1,5 @@
 require 'logging'
 require 'dalli'
-require "byebug"
 
 module MegaMutex
   class TimeoutError < RuntimeError; end

--- a/mega_mutex.gemspec
+++ b/mega_mutex.gemspec
@@ -39,9 +39,10 @@ Gem::Specification.new do |s|
      "spec/spec_helper.rb"
   ]
 
-  s.add_runtime_dependency(%q<dalli>, ["~> 2"])
+  s.add_runtime_dependency(%q<dalli>, ["~> 3"])
   s.add_runtime_dependency(%q<logging>, [">= 1.1.4"])
-  s.add_development_dependency("rspec", ["= 1.3.0"])
-  s.add_development_dependency("rake", [">= 1.0"])
 
+  s.add_development_dependency("byebug", ["~> 11.1.3"])
+  s.add_development_dependency("rake", ["~> 13.0.6"])
+  s.add_development_dependency("rspec", ["~> 3.12.0"])
 end

--- a/spec/lib/mega_mutex_spec.rb
+++ b/spec/lib/mega_mutex_spec.rb
@@ -129,5 +129,25 @@ module MegaMutex
         assert @exception.is_a?(MegaMutex::TimeoutError), "Expected TimeoutError to be raised, but wasn't"
       end
     end
+
+    describe 'with a TTL' do
+      it "should release the lock after the TTL has expired" do
+        messages = []
+
+        threads << Thread.new do
+          with_distributed_mutex('foo', :ttl => 0.2) do
+            sleep 0.4
+            messages << 'Second message'
+          end
+        end
+        threads << Thread.new do
+          with_distributed_mutex('foo') { messages << 'First message' }
+        end
+
+        wait_for_threads_to_finish
+        messages.first.should eq('First message')
+        messages.first.should eq('Second message')
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/../lib/mega_mutex')
-require 'test/unit/assertions'
 
 # Logging::Logger[:root].add_appenders(Logging::Appenders.stdout)
 
@@ -25,8 +24,7 @@ module ThreadExampleHelper
   end
 end
 
-Spec::Runner.configure do |config|
+RSpec.configure do |config|
   config.extend ThreadHelper
   config.include ThreadExampleHelper
-  config.include Test::Unit::Assertions
 end


### PR DESCRIPTION
Setting a TTL can be useful for preventing deadlocks (if the process fails inexplicably, for example). Moved from https://github.com/songkick/mega_mutex/pull/3.
