### PR TITLE
Fix race condition when setting mutex key

### DIFF
--- a/lib/mega_mutex.rb
+++ b/lib/mega_mutex.rb
@@ -104,4 +104,3 @@ module MegaMutex
     end
   end
 end
-

--- a/lib/mega_mutex/distributed_mutex.rb
+++ b/lib/mega_mutex/distributed_mutex.rb
@@ -74,9 +74,9 @@ module MegaMutex
     end
 
     def set_current_lock(new_lock)
-      cache.set(@key, my_lock_id)
-      # expire redis key after 1 hour
-      cache.expire(@key, 3600)
+      # nx: only set key if it doesn't exist
+      # px: expire redis key after 1 hour (in milliseconds)
+      cache.set(@key, my_lock_id, nx: true, px: 3_600_000)
     end
 
     def my_lock_id

--- a/mega_mutex.gemspec
+++ b/mega_mutex.gemspec
@@ -42,6 +42,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<redis>, ["~> 4"])
   s.add_runtime_dependency(%q<logging>, [">= 1.1.4"])
   s.add_development_dependency("rspec", ["= 1.3.0"])
-  s.add_development_dependency("rake", [">= 1.0"])
+  s.add_development_dependency("rake", ["< 11.0"])
 
 end

--- a/spec/lib/mega_mutex_spec.rb
+++ b/spec/lib/mega_mutex_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 module MegaMutex
   describe MegaMutex do
@@ -39,7 +39,7 @@ module MegaMutex
 
       describe "with the same lock key" do
         before(:each) do
-          Redis.new({:host => 'redis.dev', :port => 6379}).delete(mutex_id)
+          Redis.new({:host => 'redis.dev', :port => 6379}).del(mutex_id)
         end
 
         def mutex_id
@@ -106,7 +106,6 @@ module MegaMutex
     end
 
     describe "with a timeout" do
-
       it "should raise an error if the code blocks for longer than the timeout" do
         @exception = nil
         @first_thread_has_started = false
@@ -126,7 +125,8 @@ module MegaMutex
           end
         end
         wait_for_threads_to_finish
-        assert @exception.is_a?(MegaMutex::TimeoutError), "Expected TimeoutError to be raised, but wasn't"
+
+        @exception.should be_kind_of(MegaMutex::TimeoutError), "Expected TimeoutError to be raised, but wasn't"
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../lib/mega_mutex')
-require 'test/unit/assertions'
+require_relative '../lib/mega_mutex'
 
 # Logging::Logger[:root].add_appenders(Logging::Appenders.stdout)
 
@@ -28,5 +27,4 @@ end
 Spec::Runner.configure do |config|
   config.extend ThreadHelper
   config.include ThreadExampleHelper
-  config.include Test::Unit::Assertions
 end


### PR DESCRIPTION
There's the possibility of a race condition when we're acquiring a new mutex:

`DistributedMutex.attempt_to_lock` first checks if `current_lock` is nil and only then sets the mutex key. However, the command that's used there is [`SET`](https://redis.io/commands/set), which

> If key already holds a value, it is overwritten[…].

We need to either use `SETNX` (which is deprecated) or use `SET` command with the `NX` option to

> Only set the key if it does not already exist.

I'm also setting the expiration time for the key in the same command, as we don't wanna touch that if it already exists.

Had to limit the version of Rake that can be used, as it would error with newer versions.